### PR TITLE
Refactor wallet selection and listing; update to handle encrypted wal…

### DIFF
--- a/crates/core/wallet/key/src/lib.rs
+++ b/crates/core/wallet/key/src/lib.rs
@@ -188,6 +188,11 @@ pub fn list_wallet_files() -> Result<Vec<(String, bool)>, std::io::Error> {
     let kari_dir = get_kari_dir();
     let wallet_dir = kari_dir.join("wallets");
     
+    // Create wallet directory if it doesn't exist
+    if !wallet_dir.exists() {
+        fs::create_dir_all(&wallet_dir)?;
+    }
+
     // Get currently selected wallet
     let selected = get_selected_wallet().unwrap_or_default();
 
@@ -197,12 +202,20 @@ pub fn list_wallet_files() -> Result<Vec<(String, bool)>, std::io::Error> {
         let path = entry.path();
         if path.is_file() {
             if let Some(filename) = path.file_name().and_then(|s| s.to_str()) {
-                // Check if this wallet is selected
-                let is_selected = filename.trim_end_matches(".toml") == selected;
-                wallets.push((filename.to_string(), is_selected));
+                // Only include .enc files
+                if filename.ends_with(".enc") {
+                    // Check if this wallet is selected
+                    let wallet_name = filename.trim_end_matches(".enc");
+                    let is_selected = wallet_name == selected;
+                    wallets.push((filename.to_string(), is_selected));
+                }
             }
         }
     }
+
+    // Sort wallets alphabetically
+    wallets.sort_by(|a, b| a.0.cmp(&b.0));
+    
     Ok(wallets)
 }
 


### PR DESCRIPTION

This pull request includes several improvements to the wallet management functionality in the `keytool_cli` module. The changes enhance user experience by providing better feedback and ensuring the wallet directory exists before listing wallets.

Enhancements to wallet selection and display:

* [`crates/command/src/keytool_cli/mod.rs`](diffhunk://#diff-9d9d9f9c9133bd21c9053811fa3388720326c027df4752db517f327968249ddaL148-R195): Updated the wallet display logic to indicate the current selected wallet and improved input handling to allow canceling the selection process. Wallet files now end with `.enc` instead of `.toml`.

* [`crates/command/src/keytool_cli/mod.rs`](diffhunk://#diff-9d9d9f9c9133bd21c9053811fa3388720326c027df4752db517f327968249ddaL250-R276): Modified the wallet display to trim the `.enc` extension and visually distinguish the selected wallet using green and bold text.

Improvements to wallet directory management:

* [`crates/core/wallet/key/src/lib.rs`](diffhunk://#diff-4a80a78e00998cb11834be3302e5580a86c76400c1253a3252770b411d0b7ef0R191-R195): Added logic to create the wallet directory if it does not exist, ensuring the directory structure is always present.

* [`crates/core/wallet/key/src/lib.rs`](diffhunk://#diff-4a80a78e00998cb11834be3302e5580a86c76400c1253a3252770b411d0b7ef0R205-R218): Updated the wallet listing function to only include `.enc` files, check if the wallet is selected, and sort the wallets alphabetically.