### PR TITLE
Improve password input resilience with fallback mechanism

### DIFF
--- a/crates/command/src/keytool_cli/mod.rs
+++ b/crates/command/src/keytool_cli/mod.rs
@@ -433,12 +433,30 @@ fn prompt_password(confirm: bool) -> String {
     print!("Enter password for wallet: ");
     io::stdout().flush().unwrap();
 
-    let password = read_password().unwrap();
+    let password = match read_password() {
+        Ok(pwd) => pwd,
+        Err(e) => {
+            eprintln!("Error reading password: {}. Falling back to standard input.", e);
+            // Fallback to standard input when secure input fails
+            let mut input = String::new();
+            io::stdin().read_line(&mut input).expect("Failed to read input");
+            input.trim().to_string()
+        }
+    };
 
     if confirm {
         print!("Confirm password: ");
         io::stdout().flush().unwrap();
-        let confirm = read_password().unwrap();
+        
+        let confirm = match read_password() {
+            Ok(pwd) => pwd,
+            Err(e) => {
+                eprintln!("Error reading password: {}. Falling back to standard input.", e);
+                let mut input = String::new();
+                io::stdin().read_line(&mut input).expect("Failed to read input");
+                input.trim().to_string()
+            }
+        };
 
         if password != confirm {
             println!("{}", "Passwords do not match!".red());


### PR DESCRIPTION
- Add error handling for secure password reading
- Implement fallback to standard input if secure input fails
- Maintain password confirmation logic with improved error handling

## Summary

Summary about this PR

- Closes #issue