### PR TITLE
feat: Implement server initialization command and configuration setup

### DIFF
--- a/crates/command/src/server_cli/init_server.rs
+++ b/crates/command/src/server_cli/init_server.rs
@@ -1,0 +1,54 @@
+use common::{get_kanari_config_path, save_kanari_config, get_kari_dir};
+use serde_yaml::{Value, Mapping};
+use std::io;
+use colored::Colorize;
+
+fn default_keystore_path() -> String {
+    let mut path = get_kari_dir();
+    path.push("kanari_config");
+    path.push("kanari.keystore");
+    path.to_string_lossy().into_owned()
+}
+
+fn create_env_config(alias: &str, rpc: &str, ws: &str) -> Value {
+    let mut env_map = Mapping::new();
+    env_map.insert(Value::String("alias".to_string()), Value::String(alias.to_string()));
+    env_map.insert(Value::String("rpc".to_string()), Value::String(rpc.to_string()));
+    env_map.insert(Value::String("ws".to_string()), Value::String(ws.to_string()));
+    Value::Mapping(env_map)
+}
+
+pub fn init_server_config() -> io::Result<()> {
+    let config_path = get_kanari_config_path();
+
+    if config_path.exists() {
+        println!("{}", "kanari.yaml already exists. Initialization skipped.".yellow());
+        return Ok(());
+    }
+
+    let mut config = Mapping::new();
+    config.insert(
+        Value::String("keystore_path".to_string()),
+        Value::String(default_keystore_path()),
+    );
+    config.insert(
+        Value::String("active_address".to_string()),
+        Value::Null,
+    );
+
+    let envs = vec![
+        create_env_config("local", "http://127.0.0.1:30030", "ws://127.0.0.1:30031"),
+        create_env_config("dev", "https://dev-seed.kanari.site", "wss://dev-seed.kanari.site/websocket"),
+        create_env_config("test", "https://test-seed.kanari.site", "wss://test-seed.kanari.site/websocket"),
+        create_env_config("main", "https://main-seed.kanari.site", "wss://main-seed.kanari.site/websocket"),
+    ];
+
+    config.insert(Value::String("envs".to_string()), Value::Sequence(envs));
+    config.insert(Value::String("active_env".to_string()), Value::String("local".to_string()));
+
+    let yaml_value = Value::Mapping(config);
+    save_kanari_config(&yaml_value)?;
+
+    println!("{} {}", "Default kanari.yaml created at:".green(), config_path.display().to_string().bright_white());
+    Ok(())
+}

--- a/crates/command/src/server_cli/mod.rs
+++ b/crates/command/src/server_cli/mod.rs
@@ -1,5 +1,3 @@
-
-
 use std::process::exit;
 
 use colored::Colorize;
@@ -7,6 +5,7 @@ use colored::Colorize;
 
 pub mod generate_certs;
 pub mod start_server;
+pub mod init_server;
 
 struct CommandInfo {
     name: &'static str,
@@ -17,6 +16,10 @@ const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "start",
         description: "Start the Kari server",
+    },
+    CommandInfo {
+        name: "init",
+        description: "Initialize the Kari server",
     },
     CommandInfo {
         name: "generate-certs",
@@ -187,6 +190,16 @@ pub async fn handle_server_command() -> Option<String> {
                 Ok(_) => Some("SSL certificates generated successfully".to_string()),
                 Err(e) => {
                     eprintln!("{}", format!("Error generating certificates: {}", e).red().bold());
+                    None
+                }
+            }
+        }
+
+        "init" => {
+            match init_server::init_server_config() {
+                Ok(_) => Some("Kari server initialized successfully. Default kanari.yaml created.".to_string()),
+                Err(e) => {
+                    eprintln!("{}", format!("Error initializing server: {}", e).red().bold());
                     None
                 }
             }

--- a/crates/command/src/server_cli/start_server.rs
+++ b/crates/command/src/server_cli/start_server.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use network::NetworkConfig;
 use panorama::simulation::run_blockchain;
 
-use common::{get_kari_dir, load_kanari_config, save_kanari_config, load_config, save_config};
+use common::{load_kanari_config, save_kanari_config, load_config};
 use mona_blockchain::blockchain::{load_blockchain, save_blockchain};
 use mona_blockchain::chain_id::CHAIN_ID;
 use panorama::config::{configure_network,};
@@ -15,7 +15,7 @@ use tokio::time::{Duration, sleep};
 use mona_crypto::{check_wallet_exists, list_wallet_files};
 use std::sync::{Arc, Mutex};
 use serde_yaml::Value;
-use std::path::Path; // Added import
+// Removed: use std::path::Path; // No longer needed for wallet checks here
 use std::io::{self, Write};
 use std::error::Error; // For Box<dyn Error>
 
@@ -57,6 +57,15 @@ pub async fn start_server(
         .get("chain_id")
         .and_then(|v| v.as_str())
         .unwrap_or(CHAIN_ID);
+
+    // Get the local IP address earlier for consistent use in configurations
+    let determined_local_ip = match panorama::node::get_local_ip() {
+        Some(ip) => ip,
+        None => {
+            eprintln!("Warning: Could not determine local IP address. Defaulting to 127.0.0.1 for configuration purposes.");
+            "127.0.0.1".to_string()
+        }
+    };
 
     // Check if the configuration already exists
     let network_config = if config.get("rpc_port").is_some() && config.get("chain_id").is_some() {
@@ -116,7 +125,7 @@ pub async fn start_server(
             .to_string();
 
         NetworkConfig {
-            node_address: "127.0.0.1".to_string(),
+            node_address: if localhost_only { "127.0.0.1".to_string() } else { determined_local_ip.clone() },
             port: rpc_port,
             peers: if localhost_only { vec![] } else { peers }, // No peers in localhost mode
             chain_id,
@@ -222,32 +231,12 @@ pub async fn start_server(
 
     // Address selection logic updated for selected_wallet
     let address = if let Some(wallet_name) = selected_wallet {
-        let wallet_path = get_kari_dir().join("wallets").join(format!("{}.enc", wallet_name));
-        if !wallet_path.exists() {
-            println!("Selected wallet '{}' does not exist.", wallet_name.red());
-            // Try to find any existing wallet as a fallback
-            match list_wallet_files() {
-                Ok(wallets) if !wallets.is_empty() => {
-                    let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                    println!("Falling back to existing wallet: {}", first_wallet.green());
-                    if let Some(kanari_mapping) = kanari_config.as_mapping_mut() {
-                        kanari_mapping.insert(
-                            Value::String("active_address".to_string()),
-                            Value::String(first_wallet.clone()),
-                        );
-                        if let Err(e) = save_kanari_config(&kanari_config) {
-                            eprintln!("Warning: Failed to save updated kanari config: {}", e);
-                        }
-                    }
-                    first_wallet
-                }
-                _ => {
-                    println!("{}", "No other wallets found!".red());
-                    println!("Please create a wallet or ensure the selected wallet exists.");
-                    return Err(Box::from("Selected wallet not found and no fallback wallets available."));
-                }
-            }
-        } else {
+        let all_wallets = list_wallet_files().unwrap_or_else(|e| {
+            eprintln!("Warning: Failed to list wallet files: {}", e);
+            Vec::new()
+        });
+
+        if all_wallets.iter().any(|(addr, _)| addr == &wallet_name) {
             println!("Using selected wallet as address: {}", wallet_name.green());
             if let Some(kanari_mapping) = kanari_config.as_mapping_mut() {
                 kanari_mapping.insert(
@@ -259,156 +248,135 @@ pub async fn start_server(
                 }
             }
             wallet_name
+        } else {
+            println!("Selected wallet '{}' does not exist.", wallet_name.red());
+            if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                println!("Falling back to existing wallet: {}", first_wallet_addr.green());
+                if let Some(kanari_mapping) = kanari_config.as_mapping_mut() {
+                    kanari_mapping.insert(
+                        Value::String("active_address".to_string()),
+                        Value::String(first_wallet_addr.clone()),
+                    );
+                    if let Err(e) = save_kanari_config(&kanari_config) {
+                        eprintln!("Warning: Failed to save updated kanari config: {}", e);
+                    }
+                }
+                first_wallet_addr.clone()
+            } else {
+                println!("{}", "No other wallets found!".red());
+                println!("Please create a wallet or ensure the selected wallet exists.");
+                return Err(Box::from("Selected wallet not found and no fallback wallets available."));
+            }
         }
     } else {
         // Original logic if no specific wallet is selected
-        if let Some(kanari_mapping) = kanari_config.as_mapping() {
-            if let Some(addr) = kanari_mapping.get("active_address").and_then(|v| v.as_str()) {
-                if !Path::new(&get_kari_dir().join("wallets").join(format!("{}.enc", addr))).exists() {
-                    match list_wallet_files() {
-                        Ok(wallets) if !wallets.is_empty() => {
-                            let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                            println!("Active address wallet not found. Using existing wallet: {}", first_wallet.green());
-                            if let Some(kanari_mapping_mut) = kanari_config.as_mapping_mut() {
-                                kanari_mapping_mut.insert(
+        let all_wallets = list_wallet_files().unwrap_or_else(|e| {
+            eprintln!("Warning: Failed to list wallet files: {}", e);
+            Vec::new()
+        });
+
+        if let Some(kanari_mapping) = kanari_config.as_mapping_mut() { // Changed to as_mapping_mut for potential updates
+            if let Some(active_addr_str) = kanari_mapping.get("active_address").and_then(|v| v.as_str()) {
+                if all_wallets.iter().any(|(addr, _)| addr == active_addr_str) {
+                    active_addr_str.to_string()
+                } else {
+                    println!("Active address wallet '{}' not found in keystore.", active_addr_str.red());
+                    if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                        println!("Using existing wallet: {}", first_wallet_addr.green());
+                        kanari_mapping.insert(
+                            Value::String("active_address".to_string()),
+                            Value::String(first_wallet_addr.clone()),
+                        );
+                        if let Err(e) = save_kanari_config(&kanari_config) {
+                            eprintln!("Warning: Failed to save updated kanari config: {}", e);
+                        }
+                        first_wallet_addr.clone()
+                    } else {
+                        println!("{}", "No valid wallets found!".red());
+                        return Err(Box::from("No valid wallets found after checking active_address."));
+                    }
+                }
+            } else {
+                // No active_address in kanari_config, try config.yaml or list_wallet_files
+                match config.get("address").and_then(|v| v.as_str()) {
+                    Some(address_str_from_config) => {
+                        if all_wallets.iter().any(|(addr, _)| addr == address_str_from_config) {
+                            // Update kanari_config with this address
+                            kanari_mapping.insert(
+                                Value::String("active_address".to_string()),
+                                Value::String(address_str_from_config.to_string()),
+                            );
+                            if let Err(e) = save_kanari_config(&kanari_config) {
+                                eprintln!("Warning: Failed to save updated kanari config: {}", e);
+                            }
+                            address_str_from_config.to_string()
+                        } else {
+                            println!("Config address wallet '{}' not found in keystore.", address_str_from_config.red());
+                            if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                                println!("Using existing wallet: {}", first_wallet_addr.green());
+                                kanari_mapping.insert(
                                     Value::String("active_address".to_string()),
-                                    Value::String(first_wallet.clone()),
+                                    Value::String(first_wallet_addr.clone()),
                                 );
                                 if let Err(e) = save_kanari_config(&kanari_config) {
                                     eprintln!("Warning: Failed to save updated kanari config: {}", e);
                                 }
+                                first_wallet_addr.clone()
+                            } else {
+                                println!("{}", "No valid wallets found!".red());
+                                return Err(Box::from("No valid wallets found after checking config.address."));
                             }
-                            first_wallet
-                        }
-                        _ => {
-                            println!("{}", "No valid wallets found!".red());
-                            return Err(Box::from("No valid wallets found after checking active_address."));
-                        }
-                    }
-                } else {
-                    addr.to_string()
-                }
-            } else {
-                // Fall back to config.yaml or list_wallet_files
-                match config.get("address").and_then(|v| v.as_str()) {
-                    Some(address_str) => {
-                        if !Path::new(&get_kari_dir().join("wallets").join(format!("{}.enc", address_str))).exists() {
-                            match list_wallet_files() {
-                                Ok(wallets) if !wallets.is_empty() => {
-                                    let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                                    println!("Config address wallet not found. Using existing wallet: {}", first_wallet.green());
-                                     if let Some(kanari_mapping_mut) = kanari_config.as_mapping_mut() {
-                                        kanari_mapping_mut.insert( Value::String("active_address".to_string()), Value::String(first_wallet.clone()));
-                                        if let Err(e) = save_kanari_config(&kanari_config) { eprintln!("Warning: Failed to save updated kanari config: {}", e); }
-                                    }
-                                    first_wallet
-                                }
-                                _ => {
-                                    println!("{}", "No valid wallets found!".red());
-                                    return Err(Box::from("No valid wallets found after checking config.address."));
-                                }
-                            }
-                        } else {
-                            address_str.to_string()
                         }
                     }
                     None => {
-                        match list_wallet_files() {
-                            Ok(wallets) if !wallets.is_empty() => {
-                                let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                                println!("Setting address to existing wallet: {}", first_wallet.green());
-                                if let Some(kanari_mapping_mut) = kanari_config.as_mapping_mut() {
-                                    kanari_mapping_mut.insert(
-                                        Value::String("active_address".to_string()),
-                                        Value::String(first_wallet.clone()),
-                                    );
-                                    if let Err(e) = save_kanari_config(&kanari_config) {
-                                        eprintln!("Warning: Failed to save updated kanari config: {}", e);
-                                    }
-                                }
-                                first_wallet
+                        // No address in config.yaml, use first from list_wallet_files
+                        if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                            println!("Setting address to existing wallet: {}", first_wallet_addr.green());
+                            kanari_mapping.insert(
+                                Value::String("active_address".to_string()),
+                                Value::String(first_wallet_addr.clone()),
+                            );
+                            if let Err(e) = save_kanari_config(&kanari_config) {
+                                eprintln!("Warning: Failed to save updated kanari config: {}", e);
                             }
-                            _ => {
-                                println!("{}", "No wallets found!".red());
-                                return Err(Box::from("No wallets found at all."));
-                            }
+                            first_wallet_addr.clone()
+                        } else {
+                            println!("{}", "No wallets found!".red());
+                            return Err(Box::from("No wallets found at all."));
                         }
                     }
                 }
             }
         } else {
-             // Fall back to old behavior if kanari config is not available (should not happen if loaded above)
+             // Fallback if kanari_config is not a mapping (e.g., corrupted or new)
+             // This block might be less likely if kanari_config is initialized to a mapping earlier
             match config.get("address").and_then(|v| v.as_str()) {
-                Some(address_str) => {
-                     if !Path::new(&get_kari_dir().join("wallets").join(format!("{}.enc", address_str))).exists() {
-                        match list_wallet_files() {
-                            Ok(wallets) if !wallets.is_empty() => {
-                                let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                                println!("Config address wallet not found (no kanari_config). Using existing wallet: {}", first_wallet.green());
-                                first_wallet
-                            }
-                            _ => {
-                                println!("{}", "No valid wallets found!".red());
-                                return Err(Box::from("No valid wallets found (no kanari_config, config.address invalid)."));
-                            }
-                        }
+                Some(address_str_from_config) => {
+                     if all_wallets.iter().any(|(addr, _)| addr == address_str_from_config) {
+                        address_str_from_config.to_string()
                     } else {
-                        address_str.to_string()
+                        println!("Config address wallet '{}' not found (no kanari_config). Using existing wallet.", address_str_from_config.red());
+                        if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                            println!("Using existing wallet: {}", first_wallet_addr.green());
+                            first_wallet_addr.clone()
+                        } else {
+                            println!("{}", "No valid wallets found!".red());
+                            return Err(Box::from("No valid wallets found (no kanari_config, config.address invalid)."));
+                        }
                     }
                 }
                 None => {
-                    match list_wallet_files() {
-                        Ok(wallets) if !wallets.is_empty() => {
-                            let first_wallet = wallets[0].0.trim_end_matches(".enc").to_string();
-                            println!("Setting address to existing wallet (no kanari_config, no config.address): {}", first_wallet.green());
-                            first_wallet
-                        }
-                        _ => {
-                            println!("{}", "No wallets found!".red());
-                            return Err(Box::from("No wallets found (no kanari_config, no config.address)."));
-                        }
+                    if let Some((first_wallet_addr, _)) = all_wallets.first() {
+                        println!("Setting address to existing wallet (no kanari_config, no config.address): {}", first_wallet_addr.green());
+                        first_wallet_addr.clone()
+                    } else {
+                        println!("{}", "No wallets found!".red());
+                        return Err(Box::from("No wallets found (no kanari_config, no config.address)."));
                     }
                 }
             }
         }
     };
-
-
-    // Save final configuration to both config formats
-    let final_config = serde_yaml::Value::Mapping({
-        let mut map = serde_yaml::Mapping::new();
-        map.insert(
-            serde_yaml::Value::String("chain_id".to_string()),
-            serde_yaml::Value::String(network_config.chain_id.clone()),
-        );
-        map.insert(
-            serde_yaml::Value::String("rpc_port".to_string()),
-            serde_yaml::Value::Number(serde_yaml::Number::from(network_config.port)),
-        );
-
-        map.insert(
-            serde_yaml::Value::String("address".to_string()),
-            serde_yaml::Value::String(address.clone()),
-        );
-
-        // Add peers to configuration if specified
-        if !network_config.peers.is_empty() {
-            let peers_array = network_config
-                .peers
-                .iter()
-                .map(|peer| serde_yaml::Value::String(peer.clone()))
-                .collect::<Vec<_>>();
-
-            map.insert(
-                serde_yaml::Value::String("peers".to_string()),
-                serde_yaml::Value::Sequence(peers_array),
-            );
-        }
-
-        map
-    });
-
-    save_config(&final_config).expect("Failed to save configuration");
 
     // Make sure kanari.yaml has the active address
     if let Some(kanari_mapping) = kanari_config.as_mapping_mut() {
@@ -445,14 +413,8 @@ pub async fn start_server(
         run_blockchain(running_clone, address_clone, tx);
     });
 
-    // Get the local IP address
-    let local_ip = match panorama::node::get_local_ip() {
-        Some(ip) => ip,
-        None => {
-            eprintln!("Could not determine local IP address, using 127.0.0.1");
-            "127.0.0.1".to_string()
-        }
-    };
+    // Use the local IP address determined earlier
+    let local_ip = determined_local_ip;
 
     // Update RPC configuration to reflect localhost-only mode
     let rpc_config = NetworkConfig {

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -69,122 +69,93 @@ pub fn save_kanari_config(config: &Value) -> io::Result<()> {
 
 /// Load configuration (now completely from kanari.yaml)
 pub fn load_config() -> io::Result<Value> {
-    // Get configuration from kanari.yaml
     let kanari_config = load_kanari_config()?;
     
-    if let Some(active_env) = kanari_config.get("active_env").and_then(|v| v.as_str()) {
-        if let Some(envs) = kanari_config.get("envs").and_then(|v| v.as_sequence()) {
-            // Find the active environment
-            for env in envs {
-                if let Some(alias) = env.get("alias").and_then(|v| v.as_str()) {
-                    if alias == active_env {
-                        // Create a config-compatible structure
-                        let mut config = Mapping::new();
-                        
-                        // Add chain_id based on environment
-                        let chain_id = match active_env {
-                            "local" => "kari-local-001",
-                            "dev" => "kari-dev-001",
-                            "test" => "kari-testnet-001",
-                            "main" => "kari-mainnet-001",
-                            _ => "kari-testnet-001"
-                        };
-                        
-                        config.insert(
-                            Value::String("chain_id".to_string()),
-                            Value::String(chain_id.to_string())
-                        );
-                        
-                        // Add address from kanari config
-                        if let Some(addr) = kanari_config.get("active_address").and_then(|v| v.as_str()) {
-                            config.insert(
-                                Value::String("address".to_string()),
-                                Value::String(addr.to_string())
-                            );
-                        }
-                        
-                        // Add RPC port from the URL
-                        if let Some(rpc_url) = env.get("rpc").and_then(|v| v.as_str()) {
-                            if rpc_url.contains("localhost") || rpc_url.contains("127.0.0.1") {
-                                // Extract port from local URL
-                                if let Some(port_str) = rpc_url.split(':').nth(2) {
-                                    if let Ok(port) = port_str.parse::<u64>() {
-                                        config.insert(
-                                            Value::String("rpc_port".to_string()),
-                                            Value::Number(serde_yaml::Number::from(port))
-                                        );
-                                    }
-                                } else {
-                                    // Default port if not specified
-                                    config.insert(
-                                        Value::String("rpc_port".to_string()),
-                                        Value::Number(serde_yaml::Number::from(30030u64))
-                                    );
-                                }
-                            } else {
-                                // Remote server, just default to 30030 for local RPC
-                                config.insert(
-                                    Value::String("rpc_port".to_string()),
-                                    Value::Number(serde_yaml::Number::from(30030u64))
-                                );
-                            }
-                        }
-                        
-                        return Ok(Value::Mapping(config));
-                    }
-                }
-            }
+    let active_env_str = match kanari_config.get("active_env").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return Ok(Value::Mapping(Mapping::new())), // No active_env, return empty
+    };
+
+    let envs = match kanari_config.get("envs").and_then(|v| v.as_sequence()) {
+        Some(s) => s,
+        None => return Ok(Value::Mapping(Mapping::new())), // No envs sequence, return empty
+    };
+
+    if let Some(active_env_config) = envs.iter().find(|env| {
+        env.get("alias").and_then(|v| v.as_str()) == Some(active_env_str)
+    }) {
+        let mut config_map = Mapping::new();
+
+        let chain_id = match active_env_str {
+            "local" => "kari-local-001",
+            "dev" => "kari-dev-001",
+            "test" => "kari-testnet-001",
+            "main" => "kari-mainnet-001",
+            _ => "kari-testnet-001", // Default or consider error
+        };
+        config_map.insert(Value::String("chain_id".to_string()), Value::String(chain_id.to_string()));
+
+        if let Some(addr) = kanari_config.get("active_address").and_then(|v| v.as_str()) {
+            config_map.insert(Value::String("address".to_string()), Value::String(addr.to_string()));
         }
+
+        if let Some(rpc_url) = active_env_config.get("rpc").and_then(|v| v.as_str()) {
+            let rpc_port = if rpc_url.starts_with("http://127.0.0.1:") || rpc_url.starts_with("http://localhost:") {
+                rpc_url.split(':').nth(2).and_then(|p_str| p_str.parse::<u64>().ok()).unwrap_or(30030)
+            } else {
+                30030 // Default for remote or unparseable local
+            };
+            config_map.insert(Value::String("rpc_port".to_string()), Value::Number(serde_yaml::Number::from(rpc_port)));
+        } else {
+             config_map.insert(Value::String("rpc_port".to_string()), Value::Number(serde_yaml::Number::from(30030u64))); // Default if rpc field is missing
+        }
+        
+        return Ok(Value::Mapping(config_map));
     }
     
-    // Return empty config if no environment found
-    Ok(Value::Mapping(Mapping::new()))
+    Ok(Value::Mapping(Mapping::new())) // Active environment not found in envs list
 }
 
 /// Save configuration to kanari.yaml file
-pub fn save_config(config: &Value) -> io::Result<()> {
-    // Get current kanari config
+pub fn save_config(config_to_save: &Value) -> io::Result<()> {
     let mut kanari_config = load_kanari_config().unwrap_or_else(|_| Value::Mapping(Mapping::new()));
     
-    // If we have an active_env, update that environment
-    // Clone the active_env to end the immutable borrow
-    let active_env = if let Some(env) = kanari_config.get("active_env").and_then(|v| v.as_str()) {
-        env.to_string()
-    } else {
-        return Ok(());
+    let active_env_alias = match kanari_config.get("active_env").and_then(|v| v.as_str()) {
+        Some(alias) => alias.to_string(),
+        None => return Ok(()), // No active_env to update
     };
 
-    if let Some(mapping) = config.as_mapping() {
-        // Create or update the environment
-        if let Some(envs) = kanari_config.get_mut("envs").and_then(|v| v.as_sequence_mut()) {
-            // Find and update the active environment
-            for env in envs {
-                if let Some(alias) = env.get("alias").and_then(|v| v.as_str()) {
-                    if alias == active_env {
-                        // Update the RPC port if it exists in the config
-                        if let Some(rpc_port) = mapping.get("rpc_port") {
-                            if let Some(port) = rpc_port.as_u64() {
-                                env["rpc"] = Value::String(format!("http://127.0.0.1:{}", port));
-                            }
-                        }
-                        break;
+    let config_to_save_map = match config_to_save.as_mapping() {
+        Some(map) => map,
+        None => return Ok(()), // Nothing to save if not a mapping
+    };
+
+    if let Some(kanari_config_map) = kanari_config.as_mapping_mut() {
+        // Update active_address if "address" is in config_to_save
+        if let Some(addr_val) = config_to_save_map.get("address").and_then(|v| v.as_str()) {
+            kanari_config_map.insert(
+                Value::String("active_address".to_string()),
+                Value::String(addr_val.to_string()),
+            );
+        }
+
+        // Update RPC URL in the active environment if "rpc_port" is in config_to_save
+        if let Some(envs) = kanari_config_map.get_mut("envs").and_then(|v| v.as_sequence_mut()) {
+            if let Some(env_to_update) = envs.iter_mut().find(|env| {
+                env.get("alias").and_then(|v| v.as_str()) == Some(&active_env_alias)
+            }) {
+                if let Some(rpc_port_val) = config_to_save_map.get("rpc_port").and_then(|v| v.as_u64()) {
+                    if let Some(env_map_mut) = env_to_update.as_mapping_mut() {
+                        env_map_mut.insert(
+                            Value::String("rpc".to_string()),
+                            Value::String(format!("http://127.0.0.1:{}", rpc_port_val)),
+                        );
                     }
                 }
             }
         }
         
-        // Update active_address if address exists in the config
-        if let Some(addr) = mapping.get("address").and_then(|v| v.as_str()) {
-            if let Some(mapping) = kanari_config.as_mapping_mut() {
-                mapping.insert(
-                    Value::String("active_address".to_string()),
-                    Value::String(addr.to_string())
-                );
-            }
-        }
-        
-        // Save the updated kanari config
-        save_kanari_config(&kanari_config)?;
+        save_kanari_config(&Value::Mapping(kanari_config_map.clone()))?; // Clone because save_kanari_config takes &Value
     }
     
     Ok(())
@@ -192,11 +163,8 @@ pub fn save_config(config: &Value) -> io::Result<()> {
 
 /// Get current main wallet address
 pub fn get_main_wallet() -> Option<String> {
-    // Only use kanari config
-    if let Ok(kanari_config) = load_kanari_config() {
-        if let Some(addr) = kanari_config.get("active_address").and_then(|v| v.as_str()) {
-            return Some(addr.to_string());
-        }
-    }
-    None
+    load_kanari_config().ok()
+        .and_then(|config| config.get("active_address")
+            .and_then(|v| v.as_str())
+            .map(String::from))
 }

--- a/monaos/panorama/src/node/coordinator.rs
+++ b/monaos/panorama/src/node/coordinator.rs
@@ -125,7 +125,8 @@ pub fn broadcast_transaction(transaction: &Transaction) -> Result<(), Blockchain
     // Update statistics
     if success_count > 0 {
         let mut stats = NETWORK_STATS.lock().unwrap();
-        stats.transactions_sent += 1;
+        // Increments by the number of peers the transaction was successfully announced to.
+        stats.transactions_sent += success_count as u64;
         stats.last_update = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -257,16 +258,4 @@ pub fn connect_to_peer_by_name(address: &str) -> Result<String, BlockchainError>
             Err(e)
         }
     }
-}
-
-// Choose appropriate domain for network type
-pub fn get_domain_for_network(network_type: &str, is_api: bool) -> Option<String> {
-    let domain = match network_type.to_lowercase().as_str() {
-        "devnet" => if is_api { "api.devnet.kanari.site" } else { "devnet.kanari.site" },
-        "testnet" => if is_api { "api.testnet.kanari.site" } else { "testnet.kanari.site" },
-        "mainnet" => if is_api { "api.mainnet.kanari.site" } else { "mainnet.kanari.site" },
-        _ => return None,
-    };
-    
-    Some(domain.to_string())
 }

--- a/monaos/panorama/src/node/mod.rs
+++ b/monaos/panorama/src/node/mod.rs
@@ -182,26 +182,45 @@ pub fn get_local_ip() -> Option<String> {
             for server in dns_servers {
                 if socket.connect(server).is_ok() {
                     if let Ok(addr) = socket.local_addr() {
+                        debug!("Local IP determined via UDP socket connect to {}: {}", server, addr.ip());
                         return Some(addr.ip().to_string());
                     }
                 }
             }
+            warn!("Failed to determine local IP via UDP socket connect method.");
         }
-        Err(_) => {}
+        Err(e) => {
+            warn!("Failed to bind UDP socket for IP discovery: {}", e);
+        }
     }
 
     // More fallback methods for IP detection
     if let Ok(hostname_output) = std::process::Command::new("hostname").output() {
-        let hostname = String::from_utf8_lossy(&hostname_output.stdout).trim().to_string();
-        if let Ok(addrs) = hostname.to_socket_addrs() {
-            for addr in addrs {
-                if !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
-                    return Some(addr.ip().to_string());
+        let hostname_str = String::from_utf8_lossy(&hostname_output.stdout);
+        let hostname = hostname_str.trim();
+        if hostname.is_empty() {
+            warn!("Hostname command returned empty output.");
+        } else {
+            match (hostname, 0u16).to_socket_addrs() { // Use a dummy port for resolution
+                Ok(addrs) => {
+                    for addr in addrs {
+                        if !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
+                            debug!("Local IP determined via hostname ('{}') command: {}", hostname, addr.ip());
+                            return Some(addr.ip().to_string());
+                        }
+                    }
+                    warn!("No suitable IP found from hostname ('{}') resolution.", hostname);
+                }
+                Err(e) => {
+                    warn!("Failed to resolve hostname '{}' to socket addresses: {}", hostname, e);
                 }
             }
         }
+    } else {
+        warn!("Hostname command failed or could not be executed for IP discovery.");
     }
 
+    warn!("All methods to determine local IP failed.");
     None
 }
 


### PR DESCRIPTION
This pull request introduces an `init` command to initialize the Kari server with a default configuration and includes various improvements and fixes to the `start_server` functionality. The key changes focus on adding the initialization feature, improving wallet selection logic, and enhancing configuration handling.

### New Initialization Feature:
* Added `init_server` module with a `init_server_config` function to create a default `kanari.yaml` configuration file. This includes default environments (`local`, `dev`, `test`, `main`) and a default keystore path.
* Registered the `init` command in the `COMMANDS` array and integrated it into the `handle_server_command` function to handle initialization logic. [[1]](diffhunk://#diff-f989b651e268dee5f8175a318c408e0f9d1229e00c525073fe6c318b253c0c63R20-R23) [[2]](diffhunk://#diff-f989b651e268dee5f8175a318c408e0f9d1229e00c525073fe6c318b253c0c63R198-R207)

### Improvements to Wallet Selection:
* Refactored wallet selection logic in `start_server` to handle missing or invalid wallets more gracefully. This includes falling back to existing wallets or prompting the user if no wallets are available.

### Configuration Handling Enhancements:
* Introduced consistent determination of the local IP address earlier in the `start_server` function for reuse across configurations. [[1]](diffhunk://#diff-7481383839a7e2a45a3155c408341ed78a4ee758a18f4240f57e8f26872df40dR61-R69) [[2]](diffhunk://#diff-7481383839a7e2a45a3155c408341ed78a4ee758a18f4240f57e8f26872df40dL448-R417)
* Updated the `node_address` field in `NetworkConfig` to dynamically use the determined local IP or default to `127.0.0.1` when necessary.

### Code Cleanup:
* Removed unused imports and redundant code in `start_server`, such as the `Path` import and legacy configuration-saving logic. [[1]](diffhunk://#diff-7481383839a7e2a45a3155c408341ed78a4ee758a18f4240f57e8f26872df40dL18-R18) [[2]](diffhunk://#diff-7481383839a7e2a45a3155c408341ed78a4ee758a18f4240f57e8f26872df40dL448-R417)

## Summary

Summary about this PR

- Closes #issue