### PR TITLE
Add Keytool and Move CLI manuals; enhance mnemonic and session key ma…

### DIFF
--- a/crates/command/src/keytool_cli/mod.rs
+++ b/crates/command/src/keytool_cli/mod.rs
@@ -2,6 +2,8 @@ use colored::Colorize;
 use mona_crypto::{
     list_wallet_files,
     load_wallet, save_wallet, set_selected_wallet,
+    save_mnemonic, load_mnemonic, check_mnemonic_exists, remove_mnemonic, get_mnemonic_addresses,
+    save_session_key, load_session_key, remove_session_key, clear_session_keys,
 };
 use std::io::{self, Write};
 
@@ -51,6 +53,14 @@ const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "privatekey",
         description: "Import from private key",
+    },
+    CommandInfo {
+        name: "mnemonic",
+        description: "Manage BIP39 mnemonic phrases",
+    },
+    CommandInfo {
+        name: "session",
+        description: "Manage session keys",
     },
 ];
 
@@ -786,6 +796,298 @@ pub fn handle_keytool_command() -> Option<String> {
                         println!("{}", format!("Failed to read curve choice: {}", e).red());
                         return None;
                     }
+                }
+            }
+
+            "mnemonic" => {
+                // Handle mnemonic subcommands
+                if args.len() > 3 {
+                    let subcommand = &args[3];
+                    match subcommand.as_str() {
+                        "save" => {
+                            println!("Enter BIP39 mnemonic phrase:");
+                            let mut mnemonic = String::new();
+                            match io::stdin().read_line(&mut mnemonic) {
+                                Ok(_) => {
+                                    let mnemonic = mnemonic.trim();
+                                    
+                                    // Validate mnemonic (basic check for word count)
+                                    let word_count = mnemonic.split_whitespace().count();
+                                    if word_count != 12 && word_count != 24 {
+                                        println!("{}", "Invalid mnemonic: must be 12 or 24 words".red());
+                                        return None;
+                                    }
+                                    
+                                    println!("Enter associated addresses (comma-separated, or press Enter for none):");
+                                    let mut addresses_input = String::new();
+                                    match io::stdin().read_line(&mut addresses_input) {
+                                        Ok(_) => {
+                                            let addresses: Vec<String> = if addresses_input.trim().is_empty() {
+                                                Vec::new()
+                                            } else {
+                                                addresses_input
+                                                    .trim()
+                                                    .split(',')
+                                                    .map(|s| s.trim().to_string())
+                                                    .filter(|s| !s.is_empty())
+                                                    .collect()
+                                            };
+                                            
+                                            let password = prompt_password(true);
+                                            
+                                            match save_mnemonic(mnemonic, &password, addresses) {
+                                                Ok(_) => {
+                                                    println!("{}", "✓ Mnemonic saved successfully!".green().bold());
+                                                    return Some("mnemonic_saved".to_string());
+                                                }
+                                                Err(e) => {
+                                                    println!("{}", format!("Failed to save mnemonic: {}", e).red());
+                                                    return None;
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            println!("{}", format!("Error reading addresses: {}", e).red());
+                                            return None;
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    println!("{}", format!("Error reading mnemonic: {}", e).red());
+                                    return None;
+                                }
+                            }
+                        }
+                        
+                        "load" => {
+                            if !check_mnemonic_exists() {
+                                println!("{}", "No mnemonic found in keystore".yellow());
+                                return None;
+                            }
+                            
+                            let password = prompt_password(false);
+                            
+                            match load_mnemonic(&password) {
+                                Ok(mnemonic) => {
+                                    println!("\n{}", "Mnemonic Information:".bright_yellow().bold());
+                                    println!("{}", "─".repeat(60));
+                                    println!("{:<15} {}", "Mnemonic:".bold(), mnemonic.green());
+                                    
+                                    match get_mnemonic_addresses() {
+                                        Ok(addresses) => {
+                                            if !addresses.is_empty() {
+                                                println!("{:<15}", "Addresses:".bold());
+                                                for addr in addresses {
+                                                    println!("                {}", addr.green());
+                                                }
+                                            } else {
+                                                println!("{:<15} {}", "Addresses:".bold(), "None".yellow());
+                                            }
+                                        }
+                                        Err(e) => {
+                                            println!("{}", format!("Error getting addresses: {}", e).red());
+                                        }
+                                    }
+                                    println!("{}", "─".repeat(60));
+                                    
+                                    return Some("mnemonic_loaded".to_string());
+                                }
+                                Err(e) => {
+                                    println!("{}", format!("Failed to load mnemonic: {}", e).red());
+                                    return None;
+                                }
+                            }
+                        }
+                        
+                        "remove" => {
+                            if !check_mnemonic_exists() {
+                                println!("{}", "No mnemonic found in keystore".yellow());
+                                return None;
+                            }
+                            
+                            println!("{}", "⚠️  WARNING: This will permanently delete your mnemonic phrase!".red().bold());
+                            println!("Type 'CONFIRM' to proceed:");
+                            
+                            let mut confirmation = String::new();
+                            match io::stdin().read_line(&mut confirmation) {
+                                Ok(_) => {
+                                    if confirmation.trim() == "CONFIRM" {
+                                        match remove_mnemonic() {
+                                            Ok(_) => {
+                                                println!("{}", "✓ Mnemonic removed successfully".green().bold());
+                                                return Some("mnemonic_removed".to_string());
+                                            }
+                                            Err(e) => {
+                                                println!("{}", format!("Failed to remove mnemonic: {}", e).red());
+                                                return None;
+                                            }
+                                        }
+                                    } else {
+                                        println!("Operation cancelled.");
+                                        return None;
+                                    }
+                                }
+                                Err(e) => {
+                                    println!("{}", format!("Error reading confirmation: {}", e).red());
+                                    return None;
+                                }
+                            }
+                        }
+                        
+                        "status" => {
+                            if check_mnemonic_exists() {
+                                println!("{}", "✓ Mnemonic exists in keystore".green().bold());
+                                match get_mnemonic_addresses() {
+                                    Ok(addresses) => {
+                                        println!("Associated addresses: {}", addresses.len());
+                                        for addr in addresses {
+                                            println!("  - {}", addr.green());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        println!("{}", format!("Error getting addresses: {}", e).red());
+                                    }
+                                }
+                            } else {
+                                println!("{}", "No mnemonic found in keystore".yellow());
+                            }
+                            return None;
+                        }
+                        
+                        _ => {
+                            println!("{}", "Mnemonic subcommands:".bright_yellow().bold());
+                            println!("  save    - Save a BIP39 mnemonic phrase");
+                            println!("  load    - Load and display mnemonic phrase");
+                            println!("  remove  - Remove mnemonic from keystore");
+                            println!("  status  - Check mnemonic status");
+                            return None;
+                        }
+                    }
+                } else {
+                    println!("{}", "Mnemonic subcommands:".bright_yellow().bold());
+                    println!("  save    - Save a BIP39 mnemonic phrase");
+                    println!("  load    - Load and display mnemonic phrase");
+                    println!("  remove  - Remove mnemonic from keystore");
+                    println!("  status  - Check mnemonic status");
+                    return None;
+                }
+            }
+            
+            "session" => {
+                // Handle session key subcommands
+                if args.len() > 3 {
+                    let subcommand = &args[3];
+                    match subcommand.as_str() {
+                        "set" => {
+                            if args.len() > 5 {
+                                let key = &args[4];
+                                let value = &args[5];
+                                
+                                match save_session_key(key, value) {
+                                    Ok(_) => {
+                                        println!("{}", format!("✓ Session key '{}' saved", key).green().bold());
+                                        return Some(format!("session_set_{}", key));
+                                    }
+                                    Err(e) => {
+                                        println!("{}", format!("Failed to save session key: {}", e).red());
+                                        return None;
+                                    }
+                                }
+                            } else {
+                                println!("Usage: kari keytool session set <key> <value>");
+                                return None;
+                            }
+                        }
+                        
+                        "get" => {
+                            if args.len() > 4 {
+                                let key = &args[4];
+                                
+                                match load_session_key(key) {
+                                    Ok(Some(value)) => {
+                                        println!("{}: {}", key.green().bold(), value.green());
+                                        return Some(format!("session_get_{}", key));
+                                    }
+                                    Ok(None) => {
+                                        println!("{}", format!("Session key '{}' not found", key).yellow());
+                                        return None;
+                                    }
+                                    Err(e) => {
+                                        println!("{}", format!("Failed to load session key: {}", e).red());
+                                        return None;
+                                    }
+                                }
+                            } else {
+                                println!("Usage: kari keytool session get <key>");
+                                return None;
+                            }
+                        }
+                        
+                        "remove" => {
+                            if args.len() > 4 {
+                                let key = &args[4];
+                                
+                                match remove_session_key(key) {
+                                    Ok(_) => {
+                                        println!("{}", format!("✓ Session key '{}' removed", key).green().bold());
+                                        return Some(format!("session_removed_{}", key));
+                                    }
+                                    Err(e) => {
+                                        println!("{}", format!("Failed to remove session key: {}", e).red());
+                                        return None;
+                                    }
+                                }
+                            } else {
+                                println!("Usage: kari keytool session remove <key>");
+                                return None;
+                            }
+                        }
+                        
+                        "clear" => {
+                            println!("{}", "⚠️  This will remove ALL session keys. Continue? (y/n)".yellow().bold());
+                            
+                            let mut confirmation = String::new();
+                            match io::stdin().read_line(&mut confirmation) {
+                                Ok(_) => {
+                                    if confirmation.trim().eq_ignore_ascii_case("y") {
+                                        match clear_session_keys() {
+                                            Ok(_) => {
+                                                println!("{}", "✓ All session keys cleared".green().bold());
+                                                return Some("session_cleared".to_string());
+                                            }
+                                            Err(e) => {
+                                                println!("{}", format!("Failed to clear session keys: {}", e).red());
+                                                return None;
+                                            }
+                                        }
+                                    } else {
+                                        println!("Operation cancelled.");
+                                        return None;
+                                    }
+                                }
+                                Err(e) => {
+                                    println!("{}", format!("Error reading confirmation: {}", e).red());
+                                    return None;
+                                }
+                            }
+                        }
+                        
+                        _ => {
+                            println!("{}", "Session key subcommands:".bright_yellow().bold());
+                            println!("  set <key> <value>  - Save a session key");
+                            println!("  get <key>          - Get a session key value");
+                            println!("  remove <key>       - Remove a session key");
+                            println!("  clear              - Remove all session keys");
+                            return None;
+                        }
+                    }
+                } else {
+                    println!("{}", "Session key subcommands:".bright_yellow().bold());
+                    println!("  set <key> <value>  - Save a session key");
+                    println!("  get <key>          - Get a session key value");
+                    println!("  remove <key>       - Remove a session key");
+                    println!("  clear              - Remove all session keys");
+                    return None;
                 }
             }
 

--- a/docs/keytool.md
+++ b/docs/keytool.md
@@ -1,0 +1,481 @@
+# Keytool CLI Manual
+
+The Keytool CLI is a comprehensive command-line interface for managing cryptocurrency wallets, keys, and blockchain operations in the Kanari SDK.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Basic Usage](#basic-usage)
+- [Commands Overview](#commands-overview)
+- [Wallet Management](#wallet-management)
+- [Mnemonic Management](#mnemonic-management)
+- [Session Key Management](#session-key-management)
+- [Transaction Operations](#transaction-operations)
+- [Security Best Practices](#security-best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## Installation
+
+The keytool is included with the Kanari SDK. Ensure you have the `kari` binary in your PATH.
+
+```bash
+# Verify installation
+kari --version
+```
+
+## Basic Usage
+
+```bash
+kari keytool <command> [options]
+```
+
+To see all available commands:
+
+```bash
+kari keytool
+```
+
+## Commands Overview
+
+| Command | Description |
+|---------|-------------|
+| `generate` | Generate a new wallet address |
+| `balance` | Check balance of an address |
+| `transfer` | Transfer coins to another address |
+| `select` | Select an active wallet |
+| `wallet` | Load and display wallet information |
+| `list` | List all available wallets |
+| `import` | Import wallet from seed phrase |
+| `privatekey` | Import wallet from private key |
+| `mnemonic` | Manage BIP39 mnemonic phrases |
+| `session` | Manage temporary session keys |
+
+## Wallet Management
+
+### Generate New Wallet
+
+Create a new wallet with a randomly generated seed phrase:
+
+```bash
+kari keytool generate
+```
+
+**Interactive prompts:**
+1. Choose mnemonic length (12 or 24 words)
+2. Select curve type:
+   - `1` - K-256 (secp256k1) - Bitcoin-compatible
+   - `2` - P-256 (secp256r1) - NIST standard
+   - `3` - Ed25519 - Modern, fast curve
+3. Set wallet password (with confirmation)
+
+**Example output:**
+```
+Enter mnemonic length (12 or 24):
+12
+Select curve type:
+1. K-256 (secp256k1)
+2. P-256 (secp256r1)
+3. Ed25519
+1
+New address generated:
+Private Key: kanari1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0
+Public Address: 0x1234567890abcdef1234567890abcdef12345678
+Seed Phrase: word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
+Curve Type: K256
+Wallet saved successfully!
+```
+
+### Import from Seed Phrase
+
+Import an existing wallet using a BIP39 mnemonic phrase:
+
+```bash
+kari keytool import
+```
+
+**Steps:**
+1. Enter your seed phrase (12 or 24 words)
+2. Select curve type
+3. Set wallet password
+
+### Import from Private Key
+
+Import a wallet using a private key:
+
+```bash
+kari keytool privatekey
+```
+
+**Steps:**
+1. Enter your private key
+2. Select curve type
+3. Set wallet password
+
+### List Wallets
+
+Display all available wallets:
+
+```bash
+kari keytool list
+```
+
+**Example output:**
+```
+Available Wallets:
+──────────────────────────────────────────────────────────────────────
+➤ 0x1234567890abcdef1234567890abcdef12345678 [ACTIVE]
+  0x9876543210fedcba9876543210fedcba98765432
+  0xabcdef1234567890abcdef1234567890abcdef12
+──────────────────────────────────────────────────────────────────────
+Total wallets: 3
+```
+
+### Select Active Wallet
+
+Choose which wallet to use for transactions:
+
+```bash
+kari keytool select
+```
+
+**Interactive selection:**
+```
+Available wallets:
+────────────────────────────────────────────────────────────────
+No.   Address                                    Status
+────────────────────────────────────────────────────────────────
+1     0x1234567890abcdef1234567890abcdef12345678  ACTIVE
+2     0x9876543210fedcba9876543210fedcba98765432
+3     0xabcdef1234567890abcdef1234567890abcdef12
+────────────────────────────────────────────────────────────────
+
+Enter wallet number to select (or press Enter to cancel):
+2
+✓ Wallet selected: 0x9876543210fedcba9876543210fedcba98765432
+```
+
+### Load Wallet Information
+
+Display detailed information about a specific wallet:
+
+```bash
+kari keytool wallet
+```
+
+**Example output:**
+```
+Wallet Information:
+────────────────────────────────────────────────────────────────
+Address:        0x1234567890abcdef1234567890abcdef12345678
+Curve Type:     K256
+Private Key:    kanari1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0
+Seed Phrase:    word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
+────────────────────────────────────────────────────────────────
+
+✓ Wallet loaded successfully
+```
+
+## Mnemonic Management
+
+The keytool supports BIP39 mnemonic phrase management for enhanced security and backup.
+
+### Save Mnemonic
+
+Store a mnemonic phrase securely in the keystore:
+
+```bash
+kari keytool mnemonic save
+```
+
+**Steps:**
+1. Enter your BIP39 mnemonic phrase (12 or 24 words)
+2. Enter associated wallet addresses (optional)
+3. Set encryption password
+
+### Load Mnemonic
+
+Retrieve and display stored mnemonic:
+
+```bash
+kari keytool mnemonic load
+```
+
+**Example output:**
+```
+Mnemonic Information:
+────────────────────────────────────────────────────────────────
+Mnemonic:       word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
+Addresses:      
+                0x1234567890abcdef1234567890abcdef12345678
+                0x9876543210fedcba9876543210fedcba98765432
+────────────────────────────────────────────────────────────────
+```
+
+### Check Mnemonic Status
+
+Check if a mnemonic exists in the keystore:
+
+```bash
+kari keytool mnemonic status
+```
+
+### Remove Mnemonic
+
+Permanently delete stored mnemonic:
+
+```bash
+kari keytool mnemonic remove
+```
+
+**Safety confirmation required:**
+```
+⚠️  WARNING: This will permanently delete your mnemonic phrase!
+Type 'CONFIRM' to proceed:
+CONFIRM
+✓ Mnemonic removed successfully
+```
+
+## Session Key Management
+
+Manage temporary session data like authentication tokens.
+
+### Set Session Key
+
+Store a temporary key-value pair:
+
+```bash
+kari keytool session set <key> <value>
+```
+
+**Example:**
+```bash
+kari keytool session set auth_token abc123xyz
+✓ Session key 'auth_token' saved
+```
+
+### Get Session Key
+
+Retrieve a session key value:
+
+```bash
+kari keytool session get <key>
+```
+
+**Example:**
+```bash
+kari keytool session get auth_token
+auth_token: abc123xyz
+```
+
+### Remove Session Key
+
+Delete a specific session key:
+
+```bash
+kari keytool session remove <key>
+```
+
+### Clear All Session Keys
+
+Remove all stored session keys:
+
+```bash
+kari keytool session clear
+```
+
+**Confirmation required:**
+```
+⚠️  This will remove ALL session keys. Continue? (y/n)
+y
+✓ All session keys cleared
+```
+
+## Transaction Operations
+
+### Check Balance
+
+Check the balance of any address:
+
+```bash
+kari keytool balance
+```
+
+**Example:**
+```
+Enter public address:
+0x1234567890abcdef1234567890abcdef12345678
+Balance for 0x1234567890abcdef1234567890abcdef12345678: 1,250.500000000 Kari
+```
+
+### Transfer Funds
+
+Send KARI tokens to another address:
+
+```bash
+kari keytool transfer
+```
+
+**Interactive process:**
+1. Select or confirm sender wallet
+2. View current balance
+3. Enter recipient address
+4. Enter amount to send
+5. Confirm transaction details
+6. Enter wallet password
+7. Transaction submitted
+
+**Example flow:**
+```
+Your balance: 1,250.500000000 KARI
+Enter recipient address:
+0x9876543210fedcba9876543210fedcba98765432
+Enter amount to send (in KARI):
+100.5
+
+Transaction details:
+  From: 0x1234567890abcdef1234567890abcdef12345678
+  To:   0x9876543210fedcba9876543210fedcba98765432
+  Amount: 100.5 KARI
+
+Confirm transfer? (y/n)
+y
+Enter wallet password:
+Sending transaction...
+Transfer initiated successfully!
+Transaction will be included in the next block.
+Transaction ID: 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+```
+
+## Security Best Practices
+
+### Password Security
+
+1. **Use strong passwords** (minimum 12 characters)
+2. **Include mixed case, numbers, and symbols**
+3. **Never reuse passwords** across wallets
+4. **Store passwords securely** (use password managers)
+
+### Private Key Safety
+
+1. **Never share private keys** with anyone
+2. **Never store private keys** in plain text
+3. **Keep backups** in secure, offline locations
+4. **Use hardware wallets** for large amounts
+
+### Mnemonic Phrase Security
+
+1. **Write down seed phrases** on paper, never digital
+2. **Store in multiple secure locations**
+3. **Never take photos** of seed phrases
+4. **Test recovery** before storing large amounts
+
+### General Security
+
+1. **Verify addresses** before sending transactions
+2. **Start with small amounts** when testing
+3. **Keep software updated**
+4. **Use secure networks** (avoid public WiFi)
+
+## Troubleshooting
+
+### Common Issues
+
+#### "No wallets found!"
+- **Solution**: Generate or import a wallet first
+- **Command**: `kari keytool generate`
+
+#### "Invalid password"
+- **Solution**: Ensure correct password for the wallet
+- **Tip**: Passwords are case-sensitive
+
+#### "Failed to load blockchain"
+- **Solution**: Ensure the Kanari node is running
+- **Check**: Node should be accessible at `http://127.0.0.1:30031`
+
+#### "Transfer failed"
+- **Possible causes**:
+  - Insufficient balance
+  - Invalid recipient address
+  - Network connectivity issues
+  - Incorrect password
+
+#### "HTTP request failed"
+- **Solution**: Install `curl` on your system
+- **Windows**: Install via chocolatey or download
+- **Linux/Mac**: Usually pre-installed
+
+### Error Codes
+
+| Error | Description | Solution |
+|-------|-------------|----------|
+| `WalletError::NotFound` | Wallet file doesn't exist | Check wallet address |
+| `WalletError::InvalidPassword` | Wrong password | Verify password |
+| `WalletError::EncryptionError` | Encryption/decryption failed | Check password and file integrity |
+| `KeystoreError::IoError` | File system error | Check permissions and disk space |
+
+### Getting Help
+
+1. **Check this manual** for command usage
+2. **Use help command**: `kari keytool`
+3. **Check logs** for detailed error messages
+4. **Verify environment** (node running, network connectivity)
+
+### Backup and Recovery
+
+#### Create Backup
+1. **Export private keys** from important wallets
+2. **Save mnemonic phrases** securely
+3. **Backup keystore file** (located in `~/.kari/kanari_config/`)
+
+#### Recovery Process
+1. **Restore from mnemonic**: `kari keytool import`
+2. **Import private key**: `kari keytool privatekey`
+3. **Copy keystore file** to config directory
+
+## Advanced Usage
+
+### Batch Operations
+
+For multiple operations, consider scripting:
+
+```bash
+#!/bin/bash
+# Example script for checking multiple balances
+
+addresses=(
+    "0x1234567890abcdef1234567890abcdef12345678"
+    "0x9876543210fedcba9876543210fedcba98765432"
+)
+
+for addr in "${addresses[@]}"; do
+    echo "Checking balance for $addr"
+    echo "$addr" | kari keytool balance
+done
+```
+
+### Configuration
+
+The keytool uses configuration files in `~/.kari/kanari_config/`:
+
+- `kanari.yaml` - General configuration
+- `kanari.keystore` - Encrypted wallet storage
+
+### Integration
+
+The keytool can be integrated into larger applications:
+
+```bash
+# Check if wallet exists
+if kari keytool list | grep -q "0x1234..."; then
+    echo "Wallet exists"
+fi
+
+# Get balance programmatically
+balance=$(echo "0x1234..." | kari keytool balance | grep "Balance" | cut -d: -f2)
+```
+
+---
+
+**Version**: 1.0.0  
+**Last Updated**: 2024  
+**For Support**: Refer to the Kanari SDK documentation

--- a/docs/move.md
+++ b/docs/move.md
@@ -1,0 +1,662 @@
+# Move CLI Manual
+
+The Move CLI is a comprehensive command-line interface for developing, testing, and deploying Move smart contracts on the Kanari blockchain platform.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Basic Usage](#basic-usage)
+- [Commands Overview](#commands-overview)
+- [Development Workflow](#development-workflow)
+- [Building and Testing](#building-and-testing)
+- [Publishing Modules](#publishing-modules)
+- [Calling Functions](#calling-functions)
+- [Documentation and Analysis](#documentation-and-analysis)
+- [Token Module Examples](#token-module-examples)
+- [Advanced Features](#advanced-features)
+- [Troubleshooting](#troubleshooting)
+
+## Installation
+
+The Move CLI is included with the Kanari SDK. Ensure you have the `kari` binary in your PATH.
+
+```bash
+# Verify installation
+kari --version
+```
+
+## Basic Usage
+
+```bash
+kari move <command> [options]
+```
+
+To see all available commands:
+
+```bash
+kari move
+```
+
+## Commands Overview
+
+| Command | Description |
+|---------|-------------|
+| `new` | Create a new Move package |
+| `build` | Build the Move package |
+| `test` | Run Move unit tests |
+| `publish` | Publish Move module to blockchain |
+| `call` | Call a function in a deployed Move module |
+| `doc` | Generate documentation |
+| `info` | Print address information |
+| `coverage` | Inspect test coverage |
+| `disassemble` | Disassemble Move bytecode |
+| `errmap` | Generate error map |
+| `migrate` | Migrate Move module |
+| `sandbox` | Execute sandbox commands |
+
+## Development Workflow
+
+### 1. Create New Project
+
+Create a new Move package:
+
+```bash
+kari move new my_token_project
+```
+
+This creates a directory structure:
+```
+my_token_project/
+├── Move.toml
+├── sources/
+│   └── example.move
+└── tests/
+    └── example_tests.move
+```
+
+**Example Move.toml:**
+```toml
+[package]
+name = "MyTokenProject"
+version = "1.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+
+[addresses]
+std = "0x1"
+my_addr = "0x42"
+```
+
+### 2. Write Move Code
+
+**Example token module (sources/token.move):**
+```move
+module my_addr::token {
+    use std::signer;
+    
+    struct Token has key {
+        value: u64,
+    }
+    
+    public fun mint(account: &signer, value: u64) {
+        move_to(account, Token { value });
+    }
+    
+    public fun get_value(addr: address): u64 acquires Token {
+        borrow_global<Token>(addr).value
+    }
+}
+```
+
+## Building and Testing
+
+### Build Package
+
+Compile your Move code:
+
+```bash
+cd my_token_project
+kari move build
+```
+
+**Build output:**
+```
+BUILDING MyTokenProject
+Including dependency MoveStdlib
+Compiling 1 modules in MyTokenProject
+```
+
+### Run Tests
+
+Execute unit tests:
+
+```bash
+kari move test
+```
+
+**Example test file (tests/token_tests.move):**
+```move
+#[test_only]
+module my_addr::token_tests {
+    use my_addr::token;
+    use std::signer;
+    
+    #[test(account = @0x1)]
+    public fun test_mint(account: signer) {
+        token::mint(&account, 100);
+        assert!(token::get_value(signer::address_of(&account)) == 100, 0);
+    }
+}
+```
+
+### Test with Coverage
+
+Run tests with coverage analysis:
+
+```bash
+kari move test --coverage
+kari move coverage
+```
+
+## Publishing Modules
+
+### Basic Publishing
+
+Publish your module to the blockchain:
+
+```bash
+kari move publish
+```
+
+### Publishing with Parameters
+
+```bash
+kari move publish --gas-budget 5000000 --address 0x123abc --password mypassword
+```
+
+**Parameters:**
+- `--gas-budget <amount>` - Gas limit (default: 3,000,000)
+- `--address <address>` - Publisher address (uses wallet if not specified)
+- `--password <password>` - Wallet password
+- `--skip-verify` - Skip bytecode verification
+
+**Example output:**
+```
+Publishing package MyTokenProject...
+Transaction executed successfully
+Module ID: 0x123abc456def::token
+Gas used: 2,847,592
+Transaction hash: 0xabcdef1234567890...
+```
+
+### Publishing Prerequisites
+
+1. **Ensure wallet is configured:**
+```bash
+kari keytool list
+```
+
+2. **Check balance:**
+```bash
+kari keytool balance
+```
+
+3. **Verify blockchain connection:**
+```bash
+# Check if node is running
+curl http://127.0.0.1:30031
+```
+
+## Calling Functions
+
+### Basic Function Call
+
+Call a function in a deployed module:
+
+```bash
+kari move call --module-id 0x123abc::token --function get_value --args address:0x456def
+```
+
+### Function Call with Multiple Arguments
+
+```bash
+kari move call --module-id 0x123abc::token --function mint --args address:0x456def,u64:1000
+```
+
+### Call Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `--module-id` | Module address and name | `0x123::token` |
+| `--function` | Function name | `mint` |
+| `--args` | Function arguments | `u64:100,address:0x456` |
+| `--gas-budget` | Gas limit | `1000000` |
+| `--address` | Caller address | `0x123abc` |
+| `--password` | Wallet password | `mypassword` |
+
+### Argument Types
+
+| Type | Format | Example |
+|------|--------|---------|
+| `u8` | `u8:value` | `u8:255` |
+| `u64` | `u64:value` | `u64:1000000` |
+| `u128` | `u128:value` | `u128:340282366920938463463374607431768211455` |
+| `address` | `address:0x...` | `address:0x1` |
+| `bool` | `bool:true/false` | `bool:true` |
+| `vector<u8>` | `vector<u8>:hex` | `vector<u8>:0x48656c6c6f` |
+
+## Documentation and Analysis
+
+### Generate Documentation
+
+Create HTML documentation for your modules:
+
+```bash
+kari move doc
+```
+
+**Generated files:**
+```
+doc/
+├── index.html
+├── my_addr_token.html
+└── assets/
+```
+
+### Print Address Information
+
+Display address mapping:
+
+```bash
+kari move info
+```
+
+### Disassemble Bytecode
+
+View compiled bytecode:
+
+```bash
+kari move disassemble --interactive
+```
+
+### Generate Error Map
+
+Create error code mapping:
+
+```bash
+kari move errmap
+```
+
+## Token Module Examples
+
+### Complete Token Module
+
+```move
+module my_addr::advanced_token {
+    use std::signer;
+    use std::error;
+    
+    /// Token resource stored under user accounts
+    struct Token has key {
+        value: u64,
+    }
+    
+    /// Capability for minting tokens
+    struct MintCapability has key {}
+    
+    /// Error codes
+    const EINSUFFICIENT_BALANCE: u64 = 1;
+    const ENOT_AUTHORIZED: u64 = 2;
+    const EALREADY_HAS_TOKEN: u64 = 3;
+    
+    /// Initialize the token module
+    public fun initialize(account: &signer) {
+        move_to(account, MintCapability {});
+    }
+    
+    /// Mint tokens to an account
+    public fun mint(
+        _mint_cap: &MintCapability,
+        account: &signer,
+        amount: u64
+    ) {
+        let addr = signer::address_of(account);
+        if (exists<Token>(addr)) {
+            let token = borrow_global_mut<Token>(addr);
+            token.value = token.value + amount;
+        } else {
+            move_to(account, Token { value: amount });
+        }
+    }
+    
+    /// Transfer tokens between accounts
+    public fun transfer(
+        from: &signer,
+        to_addr: address,
+        amount: u64
+    ) acquires Token {
+        let from_addr = signer::address_of(from);
+        assert!(exists<Token>(from_addr), error::not_found(EINSUFFICIENT_BALANCE));
+        
+        let from_token = borrow_global_mut<Token>(from_addr);
+        assert!(from_token.value >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
+        
+        from_token.value = from_token.value - amount;
+        
+        if (exists<Token>(to_addr)) {
+            let to_token = borrow_global_mut<Token>(to_addr);
+            to_token.value = to_token.value + amount;
+        } else {
+            // This would require the recipient to sign, so we'll just abort
+            abort error::invalid_argument(EALREADY_HAS_TOKEN)
+        }
+    }
+    
+    /// Get token balance
+    public fun balance(addr: address): u64 acquires Token {
+        if (exists<Token>(addr)) {
+            borrow_global<Token>(addr).value
+        } else {
+            0
+        }
+    }
+}
+```
+
+### Deployment and Usage Examples
+
+1. **Deploy the module:**
+```bash
+kari move publish --gas-budget 5000000
+```
+
+2. **Initialize token system:**
+```bash
+kari move call --module-id 0x123::advanced_token --function initialize
+```
+
+3. **Mint tokens:**
+```bash
+kari move call --module-id 0x123::advanced_token --function mint --args address:0x456,u64:1000
+```
+
+4. **Check balance:**
+```bash
+kari move call --module-id 0x123::advanced_token --function balance --args address:0x456
+```
+
+5. **Transfer tokens:**
+```bash
+kari move call --module-id 0x123::advanced_token --function transfer --args address:0x789,u64:100
+```
+
+## Advanced Features
+
+### Working with Capabilities
+
+Move uses capability-based security. Here's an example:
+
+```move
+module my_addr::capability_example {
+    struct AdminCap has key, store {}
+    
+    public fun create_admin(account: &signer) {
+        move_to(account, AdminCap {});
+    }
+    
+    public fun admin_only_function(_admin_cap: &AdminCap) {
+        // Only callable with admin capability
+    }
+}
+```
+
+### Resource Management
+
+Resources in Move are linear types that must be moved or destroyed:
+
+```move
+module my_addr::resource_example {
+    struct Coin has key {
+        value: u64,
+    }
+    
+    public fun withdraw(account: &signer, amount: u64): Coin acquires Coin {
+        let addr = signer::address_of(account);
+        let coin = borrow_global_mut<Coin>(addr);
+        coin.value = coin.value - amount;
+        Coin { value: amount }
+    }
+    
+    public fun deposit(account: &signer, coin: Coin) acquires Coin {
+        let Coin { value } = coin; // Destructure to extract value
+        let addr = signer::address_of(account);
+        let existing_coin = borrow_global_mut<Coin>(addr);
+        existing_coin.value = existing_coin.value + value;
+    }
+}
+```
+
+### Generic Programming
+
+Move supports generic types and functions:
+
+```move
+module my_addr::generic_example {
+    struct Container<T: store> has key {
+        item: T,
+    }
+    
+    public fun store_item<T: store>(account: &signer, item: T) {
+        move_to(account, Container { item });
+    }
+    
+    public fun retrieve_item<T: store>(addr: address): T acquires Container {
+        let Container { item } = move_from<Container<T>>(addr);
+        item
+    }
+}
+```
+
+### Module Dependencies
+
+**Move.toml with dependencies:**
+```toml
+[package]
+name = "MyDApp"
+version = "1.0.0"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "main" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework", rev = "main" }
+
+[addresses]
+std = "0x1"
+aptos_framework = "0x1"
+my_addr = "0x42"
+```
+
+## Troubleshooting
+
+### Common Build Errors
+
+#### "Module not found"
+```
+error: Unbound module 'my_addr::nonexistent'
+```
+**Solution:** Check module names and addresses in Move.toml
+
+#### "Address not found"
+```
+error: Invalid address '0xinvalid'
+```
+**Solution:** Ensure addresses are properly formatted (0x prefix, correct length)
+
+#### "Resource not found"
+```
+error: Resource does not exist at address
+```
+**Solution:** Ensure resources are properly initialized before access
+
+### Common Publishing Errors
+
+#### "Insufficient gas"
+```
+Transaction failed: Out of gas
+```
+**Solution:** Increase gas budget:
+```bash
+kari move publish --gas-budget 10000000
+```
+
+#### "Module verification failed"
+```
+error: Bytecode verification error
+```
+**Solution:** Check for compilation errors or use `--skip-verify`:
+```bash
+kari move publish --skip-verify
+```
+
+#### "Insufficient balance"
+```
+error: Account balance too low
+```
+**Solution:** Check account balance and add funds:
+```bash
+kari keytool balance
+```
+
+### Common Function Call Errors
+
+#### "Function not found"
+```
+error: Function 'nonexistent_function' not found
+```
+**Solution:** Verify function name and module address
+
+#### "Type mismatch"
+```
+error: Expected u64, found u8
+```
+**Solution:** Check argument types:
+```bash
+# Wrong
+kari move call --module-id 0x123::token --function mint --args u8:100
+
+# Correct
+kari move call --module-id 0x123::token --function mint --args u64:100
+```
+
+#### "Permission denied"
+```
+error: EINSUFFICIENT_PRIVILEGE
+```
+**Solution:** Ensure you have the required capabilities or are calling from the correct address
+
+### Debugging Tips
+
+1. **Use verbose mode:**
+```bash
+kari move build --verbose
+```
+
+2. **Check bytecode:**
+```bash
+kari move disassemble --debug
+```
+
+3. **Run tests frequently:**
+```bash
+kari move test --verbose
+```
+
+4. **Use print statements in tests:**
+```move
+#[test]
+fun debug_test() {
+    std::debug::print(&string::utf8(b"Debug message"));
+}
+```
+
+### Environment Issues
+
+#### "Node not running"
+```
+error: Connection refused (127.0.0.1:30031)
+```
+**Solution:** Start the Kanari node:
+```bash
+kari node start
+```
+
+#### "Wallet not configured"
+```
+error: No wallet found
+```
+**Solution:** Create or import a wallet:
+```bash
+kari keytool generate
+```
+
+### Performance Optimization
+
+1. **Optimize gas usage:**
+   - Use efficient data structures
+   - Minimize storage operations
+   - Batch operations when possible
+
+2. **Module size optimization:**
+   - Split large modules
+   - Remove unused dependencies
+   - Use generic functions
+
+3. **Testing strategy:**
+   - Write comprehensive unit tests
+   - Use property-based testing
+   - Test edge cases
+
+## Best Practices
+
+### Code Organization
+
+1. **Module structure:**
+```
+sources/
+├── core/
+│   ├── token.move
+│   └── governance.move
+├── utils/
+│   └── math.move
+└── tests/
+    ├── token_tests.move
+    └── governance_tests.move
+```
+
+2. **Naming conventions:**
+   - Modules: `snake_case`
+   - Functions: `snake_case`
+   - Structs: `PascalCase`
+   - Constants: `UPPER_CASE`
+
+### Security Considerations
+
+1. **Capability-based access control**
+2. **Resource linear typing**
+3. **Input validation**
+4. **Error handling**
+5. **Test coverage**
+
+### Development Workflow
+
+1. **Write tests first** (TDD approach)
+2. **Compile frequently** to catch errors early
+3. **Use version control** for your Move projects
+4. **Document your code** with comments
+5. **Review before publishing** to mainnet
+
+---
+
+**Version**: 1.0.0  
+**Last Updated**: 2024  
+**For Support**: Refer to the Kanari SDK documentation or Move language documentation

--- a/monaos/mona-crypto/README.md
+++ b/monaos/mona-crypto/README.md
@@ -85,16 +85,61 @@ let signature = wallet.sign(message, password)
     .expect("Failed to sign message");
 ```
 
+### Mnemonic Operations
+
+```rust
+use mona_crypto::{save_mnemonic, load_mnemonic, check_mnemonic_exists};
+
+// Save mnemonic phrase (BIP39)
+let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+let addresses = vec!["0x123...".to_string(), "0x456...".to_string()];
+save_mnemonic(mnemonic, password, addresses)
+    .expect("Failed to save mnemonic");
+
+// Load mnemonic phrase
+if check_mnemonic_exists() {
+    let loaded_mnemonic = load_mnemonic(password)
+        .expect("Failed to load mnemonic");
+    println!("Mnemonic loaded successfully");
+}
+
+// Get addresses derived from mnemonic
+let mnemonic_addresses = get_mnemonic_addresses()
+    .expect("Failed to get mnemonic addresses");
+```
+
+### Session Key Management
+
+```rust
+use mona_crypto::{save_session_key, load_session_key, clear_session_keys};
+
+// Save temporary session data
+save_session_key("auth_token", "abc123")
+    .expect("Failed to save session key");
+
+// Load session data
+if let Some(token) = load_session_key("auth_token")
+    .expect("Failed to load session key") {
+    println!("Auth token: {}", token);
+}
+
+// Clear all session keys (e.g., on logout)
+clear_session_keys()
+    .expect("Failed to clear session keys");
+```
+
 ## Security Best Practices
 
 1. **Never hardcode passwords** in your application
 2. **Always use strong, unique passwords** for wallet encryption (use `is_password_strong` function)
-3. **Never print or log private keys** - they should never be exposed
+3. **Never print or log private keys or mnemonics** - they should never be exposed
 4. **Clear sensitive data from memory** after use with `secure_clear` or `secure_erase`
 5. **Verify signatures with correct curve type** when possible
 6. **Always validate user input** before processing cryptographic operations
 7. **Use password-based key derivation** for all encryption operations
 8. **Implement proper error handling** without revealing sensitive details in error messages
+9. **Clear session keys on logout** to prevent unauthorized access
+10. **Store mnemonics securely** and never expose them in logs or error messages
 
 ## License
 

--- a/monaos/mona-crypto/src/keystore.rs
+++ b/monaos/mona-crypto/src/keystore.rs
@@ -138,6 +138,72 @@ impl Keystore {
     pub fn list_wallets(&self) -> Vec<String> {
         self.keys.keys().cloned().collect()
     }
+    
+    /// Set encrypted mnemonic phrase
+    pub fn set_mnemonic(&mut self, encrypted_mnemonic: EncryptedData, addresses: Vec<String>) -> Result<(), KeystoreError> {
+        self.mnemonic.mnemonic_phrase_encryption = Some(encrypted_mnemonic);
+        self.mnemonic.addresses = addresses;
+        self.save()?;
+        Ok(())
+    }
+    
+    /// Get encrypted mnemonic phrase
+    pub fn get_mnemonic(&self) -> Option<&EncryptedData> {
+        self.mnemonic.mnemonic_phrase_encryption.as_ref()
+    }
+    
+    /// Get addresses derived from mnemonic
+    pub fn get_mnemonic_addresses(&self) -> &Vec<String> {
+        &self.mnemonic.addresses
+    }
+    
+    /// Add address to mnemonic-derived addresses
+    pub fn add_mnemonic_address(&mut self, address: &str) -> Result<(), KeystoreError> {
+        if !self.mnemonic.addresses.contains(&address.to_string()) {
+            self.mnemonic.addresses.push(address.to_string());
+            self.save()?;
+        }
+        Ok(())
+    }
+    
+    /// Remove mnemonic and all associated data
+    pub fn remove_mnemonic(&mut self) -> Result<(), KeystoreError> {
+        self.mnemonic.mnemonic_phrase_encryption = None;
+        self.mnemonic.addresses.clear();
+        self.save()?;
+        Ok(())
+    }
+    
+    /// Add session key
+    pub fn add_session_key(&mut self, key: &str, value: &str) -> Result<(), KeystoreError> {
+        self.session_keys.insert(key.to_string(), value.to_string());
+        self.save()?;
+        Ok(())
+    }
+    
+    /// Get session key
+    pub fn get_session_key(&self, key: &str) -> Option<&String> {
+        self.session_keys.get(key)
+    }
+    
+    /// Remove session key
+    pub fn remove_session_key(&mut self, key: &str) -> Result<(), KeystoreError> {
+        self.session_keys.remove(key);
+        self.save()?;
+        Ok(())
+    }
+    
+    /// Clear all session keys
+    pub fn clear_session_keys(&mut self) -> Result<(), KeystoreError> {
+        self.session_keys.clear();
+        self.save()?;
+        Ok(())
+    }
+    
+    /// Check if mnemonic exists
+    pub fn has_mnemonic(&self) -> bool {
+        self.mnemonic.mnemonic_phrase_encryption.is_some()
+    }
 }
 
 /// Get path to the keystore file

--- a/monaos/mona-crypto/src/lib.rs
+++ b/monaos/mona-crypto/src/lib.rs
@@ -42,9 +42,16 @@ pub use wallet::{
     get_selected_wallet,
     set_selected_wallet,
     check_wallet_exists,
+    save_mnemonic,
+    load_mnemonic,
+    check_mnemonic_exists,
+    remove_mnemonic,
+    get_mnemonic_addresses,
+    save_session_key,
+    load_session_key,
+    remove_session_key,
+    clear_session_keys,
 };
-
-
 
 // Re-export keystore functionality
 pub use keystore::{

--- a/monaos/mona-crypto/src/wallet.rs
+++ b/monaos/mona-crypto/src/wallet.rs
@@ -259,6 +259,138 @@ pub fn load_wallet(address: &str, password: &str) -> Result<Wallet, WalletError>
     }
 }
 
+/// Save mnemonic phrase to keystore
+pub fn save_mnemonic(
+    mnemonic: &str,
+    password: &str,
+    addresses: Vec<String>,
+) -> Result<(), WalletError> {
+    // Validate inputs
+    if password.is_empty() {
+        return Err(WalletError::EncryptionError("Empty password not allowed".to_string()));
+    }
+    
+    if mnemonic.is_empty() {
+        return Err(WalletError::EncryptionError("Empty mnemonic not allowed".to_string()));
+    }
+    
+    // Compress mnemonic before encryption
+    let compressed_data = compression::compress_data(mnemonic.as_bytes())
+        .map_err(|e| WalletError::SerializationError(format!("Compression error: {}", e)))?;
+    
+    // Encrypt the mnemonic
+    let encrypted_data = encryption::encrypt_data(&compressed_data, password)
+        .map_err(|e| WalletError::EncryptionError(e.to_string()))?;
+    
+    // Load keystore and save mnemonic
+    let mut keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    keystore.set_mnemonic(encrypted_data, addresses)
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Load mnemonic phrase from keystore
+pub fn load_mnemonic(password: &str) -> Result<String, WalletError> {
+    // Validate inputs
+    if password.is_empty() {
+        return Err(WalletError::InvalidPassword);
+    }
+    
+    // Load keystore
+    let keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    // Get encrypted mnemonic
+    let encrypted_data = keystore.get_mnemonic()
+        .ok_or_else(|| WalletError::NotFound("Mnemonic not found".to_string()))?;
+    
+    // Decrypt mnemonic
+    let decrypted = encryption::decrypt_data(encrypted_data, password)
+        .map_err(|_| WalletError::InvalidPassword)?;
+    
+    // Decompress the decrypted data
+    let decompressed_data = compression::decompress_data(&decrypted)
+        .map_err(|e| WalletError::DecryptionError(format!("Failed to decompress mnemonic: {}", e)))?;
+    
+    // Convert to string
+    String::from_utf8(decompressed_data)
+        .map_err(|e| WalletError::DecryptionError(format!("Invalid UTF-8 in mnemonic: {}", e)))
+}
+
+/// Get addresses derived from mnemonic
+pub fn get_mnemonic_addresses() -> Result<Vec<String>, WalletError> {
+    let keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(keystore.get_mnemonic_addresses().clone())
+}
+
+/// Check if mnemonic exists in keystore
+pub fn check_mnemonic_exists() -> bool {
+    if let Ok(keystore) = Keystore::load() {
+        keystore.has_mnemonic()
+    } else {
+        false
+    }
+}
+
+/// Remove mnemonic from keystore
+pub fn remove_mnemonic() -> Result<(), WalletError> {
+    let mut keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    keystore.remove_mnemonic()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Session key management functions
+
+/// Save session key
+pub fn save_session_key(key: &str, value: &str) -> Result<(), WalletError> {
+    let mut keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    keystore.add_session_key(key, value)
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Load session key
+pub fn load_session_key(key: &str) -> Result<Option<String>, WalletError> {
+    let keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(keystore.get_session_key(key).cloned())
+}
+
+/// Remove session key
+pub fn remove_session_key(key: &str) -> Result<(), WalletError> {
+    let mut keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    keystore.remove_session_key(key)
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Clear all session keys
+pub fn clear_session_keys() -> Result<(), WalletError> {
+    let mut keystore = Keystore::load()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    keystore.clear_session_keys()
+        .map_err(|e| WalletError::KeystoreError(e.to_string()))?;
+    
+    Ok(())
+}
+
 /// Check if any wallets exist
 pub fn check_wallet_exists() -> bool {
     if let Ok(keystore) = Keystore::load() {


### PR DESCRIPTION
This pull request introduces major enhancements to the `mona_crypto` library and its CLI tool, focusing on mnemonic phrase management and session key operations. The changes include new functionality for securely handling BIP39 mnemonic phrases and session keys, updates to the CLI commands, and improvements to the library's documentation and keystore implementation.

### CLI Enhancements:
* Added support for managing BIP39 mnemonic phrases (`save`, `load`, `remove`, `status`) in the CLI, with validation for word count and secure storage.
* Introduced session key management commands (`set`, `get`, `remove`, `clear`) to handle temporary session data in the CLI.
* Updated the `COMMANDS` constant to include new commands for mnemonic and session management.

### Library Updates:
* Extended the `Keystore` struct with methods for managing encrypted mnemonic phrases (`set_mnemonic`, `get_mnemonic`, `remove_mnemonic`) and session keys (`add_session_key`, `get_session_key`, `remove_session_key`, `clear_session_keys`).
* Re-exported new mnemonic and session key management functions (`save_mnemonic`, `load_mnemonic`, `check_mnemonic_exists`, etc.) in `mona_crypto/src/lib.rs`.

### Documentation Improvements:
* Added examples for mnemonic operations and session key management in the `README.md`, highlighting usage patterns and best practices.
* Updated security guidelines to emphasize the secure handling of mnemonics and session keys.

## Summary

Summary about this PR

- Closes #issue